### PR TITLE
Added playshell : This is a PlayScript REPL (aka: like csharp REPL)

### DIFF
--- a/CI/mono.master.sync.sh
+++ b/CI/mono.master.sync.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+git checkout master
+git fetch http://github.com/mono/mono.git master 
+git merge FETCH_HEAD
+git push http://github.com/playscriptredux/playscript

--- a/CI/upstream.master.sync.sh
+++ b/CI/upstream.master.sync.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-git checkout master
-git fetch upstream
-git merge upstream/master
-git push origin master
-

--- a/mcs.master/mcs.master.mdw
+++ b/mcs.master/mcs.master.mdw
@@ -1,0 +1,6 @@
+<WorkspaceItem ctype="Workspace">
+  <Items>
+    <Item>../mcs/tools/playshell/PlayShell.sln</Item>
+    <Item>../mcs/tools/csharp/csharp.sln</Item>
+  </Items>
+</WorkspaceItem>

--- a/mcs/class/Mono.CSharp/Mono.CSharp.csproj
+++ b/mcs/class/Mono.CSharp/Mono.CSharp.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{817CE046-07E8-409D-84BF-A6EA4F2879DE}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -32,6 +30,8 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -54,27 +54,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.XML" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\class\corlib\Mono.Security.Cryptography\CryptoConvert.cs">
-      <Link>CryptoConvert.cs</Link>
-    </Compile>
-    <Compile Include="..\..\class\Mono.CompilerServices.SymbolWriter\MonoSymbolFile.cs">
-      <Link>MonoSymbolFile.cs</Link>
-    </Compile>
-    <Compile Include="..\..\class\Mono.CompilerServices.SymbolWriter\MonoSymbolTable.cs">
-      <Link>MonoSymbolTable.cs</Link>
-    </Compile>
-    <Compile Include="..\..\class\Mono.CompilerServices.SymbolWriter\MonoSymbolWriter.cs">
-      <Link>MonoSymbolWriter.cs</Link>
-    </Compile>
-    <Compile Include="..\..\class\Mono.CompilerServices.SymbolWriter\SourceMethodBuilder.cs">
-      <Link>SourceMethodBuilder.cs</Link>
-    </Compile>
     <Compile Include="..\..\mcs\anonymous.cs">
       <Link>anonymous.cs</Link>
     </Compile>
@@ -125,9 +108,6 @@
     </Compile>
     <Compile Include="..\..\mcs\delegate.cs">
       <Link>delegate.cs</Link>
-    </Compile>
-    <Compile Include="..\..\mcs\doc-bootstrap.cs">
-      <Link>doc-bootstrap.cs</Link>
     </Compile>
     <Compile Include="..\..\mcs\doc.cs">
       <Link>doc.cs</Link>
@@ -231,7 +211,57 @@
     <Compile Include="..\..\tools\monop\outline.cs">
       <Link>outline.cs</Link>
     </Compile>
-    <Compile Include="cs-parser.cs" />
+    <Compile Include="..\..\mcs\ps-lang.cs">
+      <Link>ps-lang.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\ps-tokenizer.cs">
+      <Link>ps-tokenizer.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\ps-codegen.cs">
+      <Link>ps-codegen.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\cxx-emit.cs">
+      <Link>cxx-emit.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\cxx-target.cs">
+      <Link>cxx-target.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\inliner.cs">
+      <Link>inliner.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\intrinsics.cs">
+      <Link>intrinsics.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\js-emit.cs">
+      <Link>js-emit.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\js-target.cs">
+      <Link>js-target.cs</Link>
+    </Compile>
+    <Compile Include="..\..\build\common\Consts.cs">
+      <Link>Consts.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\cs-parser.cs">
+      <Link>cs-parser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\ps-parser.cs">
+      <Link>ps-parser.cs</Link>
+    </Compile>
+    <Compile Include="Assembly\AssemblyInfo.cs">
+      <Link>AssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\Mono.CompilerServices.SymbolWriter\MonoSymbolFile.cs">
+      <Link>MonoSymbolFile.cs</Link>
+    </Compile>
+    <Compile Include="..\Mono.CompilerServices.SymbolWriter\MonoSymbolTable.cs">
+      <Link>MonoSymbolTable.cs</Link>
+    </Compile>
+    <Compile Include="..\Mono.CompilerServices.SymbolWriter\SourceMethodBuilder.cs">
+      <Link>SourceMethodBuilder.cs</Link>
+    </Compile>
+    <Compile Include="..\Mono.Security\Mono.Security.Cryptography\CryptoConvert.cs">
+      <Link>CryptoConvert.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/mcs/class/Mono.CSharp/Mono.CSharp.sln
+++ b/mcs/class/Mono.CSharp/Mono.CSharp.sln
@@ -1,12 +1,7 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.CSharp", "Mono.CSharp.csproj", "{817CE046-07E8-409D-84BF-A6EA4F2879DE}"
-	ProjectSection(ProjectDependencies) = postProject
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537} = {5D485D32-3B9F-4287-AB24-C8DA5B89F537}
-	EndProjectSection
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "jay2010", "..\..\jay\jay2010.vcxproj", "{5D485D32-3B9F-4287-AB24-C8DA5B89F537}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -28,16 +23,6 @@ Global
 		{817CE046-07E8-409D-84BF-A6EA4F2879DE}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{817CE046-07E8-409D-84BF-A6EA4F2879DE}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{817CE046-07E8-409D-84BF-A6EA4F2879DE}.Release|Win32.ActiveCfg = Release|Any CPU
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Debug|Any CPU.ActiveCfg = Debug|Win32
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Debug|Mixed Platforms.Build.0 = Debug|Win32
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Debug|Win32.ActiveCfg = Debug|Win32
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Debug|Win32.Build.0 = Debug|Win32
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Release|Any CPU.ActiveCfg = Release|Win32
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Release|Mixed Platforms.ActiveCfg = Release|Win32
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Release|Mixed Platforms.Build.0 = Release|Win32
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Release|Win32.ActiveCfg = Release|Win32
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Release|Win32.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/mcs/class/Mono.PlayScript/Makefile
+++ b/mcs/class/Mono.PlayScript/Makefile
@@ -4,7 +4,8 @@ include ../../build/rules.make
 
 LIBRARY = Mono.PlayScript.dll
 
-LIB_MCS_FLAGS = -r:System.Core.dll -r:System.Xml.dll -r:System.dll
+LIB_MCS_FLAGS = -r:System.Core.dll -r:System.Xml.dll -r:System.dll 
+LIB_MCS_FLAGS += -d:PLAYSCRIPT_REPL
 
 TEST_MCS_FLAGS = -r:System.Core.dll
 

--- a/mcs/class/Mono.PlayScript/Mono.PlayScript.csproj
+++ b/mcs/class/Mono.PlayScript/Mono.PlayScript.csproj
@@ -3,14 +3,12 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{D9F458AE-7290-4246-8E89-967D41C838CF}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mono.PlayScript</RootNamespace>
     <AssemblyName>Mono.PlayScript</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -32,49 +30,32 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
+    <ReleaseVersion>1.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_4_0</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_0;PLAYSCRIPT_REPL;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;NET_4_0</DefineConstants>
+    <DefineConstants>TRACE;NET_4_0;PLAYSCRIPT_REPL;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.XML" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\class\corlib\Mono.Security.Cryptography\CryptoConvert.cs">
-      <Link>CryptoConvert.cs</Link>
-    </Compile>
-    <Compile Include="..\..\class\Mono.CompilerServices.SymbolWriter\MonoSymbolFile.cs">
-      <Link>MonoSymbolFile.cs</Link>
-    </Compile>
-    <Compile Include="..\..\class\Mono.CompilerServices.SymbolWriter\MonoSymbolTable.cs">
-      <Link>MonoSymbolTable.cs</Link>
-    </Compile>
-    <Compile Include="..\..\class\Mono.CompilerServices.SymbolWriter\MonoSymbolWriter.cs">
-      <Link>MonoSymbolWriter.cs</Link>
-    </Compile>
-    <Compile Include="..\..\class\Mono.CompilerServices.SymbolWriter\SourceMethodBuilder.cs">
-      <Link>SourceMethodBuilder.cs</Link>
-    </Compile>
     <Compile Include="..\..\mcs\anonymous.cs">
       <Link>anonymous.cs</Link>
     </Compile>
@@ -117,17 +98,17 @@
     <Compile Include="..\..\mcs\convert.cs">
       <Link>convert.cs</Link>
     </Compile>
-    <Compile Include="..\..\mcs\cs-tokenizer.cs">
-      <Link>cs-tokenizer.cs</Link>
+    <Compile Include="..\..\mcs\ps-parser.cs">
+      <Link>ps-parser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\ps-tokenizer.cs">
+      <Link>ps-tokenizer.cs</Link>
     </Compile>
     <Compile Include="..\..\mcs\decl.cs">
       <Link>decl.cs</Link>
     </Compile>
     <Compile Include="..\..\mcs\delegate.cs">
       <Link>delegate.cs</Link>
-    </Compile>
-    <Compile Include="..\..\mcs\doc-bootstrap.cs">
-      <Link>doc-bootstrap.cs</Link>
     </Compile>
     <Compile Include="..\..\mcs\doc.cs">
       <Link>doc.cs</Link>
@@ -143,9 +124,6 @@
     </Compile>
     <Compile Include="..\..\mcs\enum.cs">
       <Link>enum.cs</Link>
-    </Compile>
-    <Compile Include="..\..\mcs\eval.cs">
-      <Link>eval.cs</Link>
     </Compile>
     <Compile Include="..\..\mcs\expression.cs">
       <Link>expression.cs</Link>
@@ -231,27 +209,60 @@
     <Compile Include="..\..\tools\monop\outline.cs">
       <Link>outline.cs</Link>
     </Compile>
-    <Compile Include="cs-parser.cs" />
+    <Compile Include="..\..\mcs\ps-lang.cs">
+      <Link>ps-lang.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\ps-codegen.cs">
+      <Link>ps-codegen.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\cxx-emit.cs">
+      <Link>cxx-emit.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\cxx-target.cs">
+      <Link>cxx-target.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\inliner.cs">
+      <Link>inliner.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\intrinsics.cs">
+      <Link>intrinsics.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\js-emit.cs">
+      <Link>js-emit.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\js-target.cs">
+      <Link>js-target.cs</Link>
+    </Compile>
+    <Compile Include="..\..\build\common\Consts.cs">
+      <Link>Consts.cs</Link>
+    </Compile>
+    <Compile Include="Assembly\AssemblyInfo.cs">
+      <Link>AssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\cs-parser.cs">
+      <Link>cs-parser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\cs-tokenizer.cs">
+      <Link>cs-tokenizer.cs</Link>
+    </Compile>
+    <Compile Include="..\..\mcs\eval.cs">
+      <Link>eval.cs</Link>
+    </Compile>
+    <Compile Include="..\Mono.CompilerServices.SymbolWriter\MonoSymbolFile.cs">
+      <Link>MonoSymbolFile.cs</Link>
+    </Compile>
+    <Compile Include="..\Mono.CompilerServices.SymbolWriter\MonoSymbolTable.cs">
+      <Link>MonoSymbolTable.cs</Link>
+    </Compile>
+    <Compile Include="..\Mono.CompilerServices.SymbolWriter\SourceMethodBuilder.cs">
+      <Link>SourceMethodBuilder.cs</Link>
+    </Compile>
+    <Compile Include="..\Mono.Security\Mono.Security.Cryptography\CryptoConvert.cs">
+      <Link>CryptoConvert.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
-      <Visible>False</Visible>
-      <ProductName>Windows Installer 3.1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
@@ -264,4 +275,9 @@
   <PropertyGroup>
     <PreBuildEvent>"$(ProjectDir)..\..\jay\jay" -cvt &lt; "$(ProjectDir)..\..\jay\skeleton.cs" "$(ProjectDir)..\..\mcs\cs-parser.jay" &gt; "$(ProjectDir)cs-parser.cs"</PreBuildEvent>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\..\mcs\ps-eval.cs">
+      <Link>ps-eval.cs</Link>
+    </None>
+  </ItemGroup>
 </Project>

--- a/mcs/class/Mono.PlayScript/Mono.PlayScript.sln
+++ b/mcs/class/Mono.PlayScript/Mono.PlayScript.sln
@@ -2,11 +2,6 @@
 Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.PlayScript", "Mono.PlayScript.csproj", "{D9F458AE-7290-4246-8E89-967D41C838CF}"
-	ProjectSection(ProjectDependencies) = postProject
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537} = {5D485D32-3B9F-4287-AB24-C8DA5B89F537}
-	EndProjectSection
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "jay2010", "..\..\jay\jay2010.vcxproj", "{5D485D32-3B9F-4287-AB24-C8DA5B89F537}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -28,16 +23,6 @@ Global
 		{D9F458AE-7290-4246-8E89-967D41C838CF}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{D9F458AE-7290-4246-8E89-967D41C838CF}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{D9F458AE-7290-4246-8E89-967D41C838CF}.Release|Win32.ActiveCfg = Release|Any CPU
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Debug|Any CPU.ActiveCfg = Debug|Win32
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Debug|Mixed Platforms.Build.0 = Debug|Win32
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Debug|Win32.ActiveCfg = Debug|Win32
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Debug|Win32.Build.0 = Debug|Win32
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Release|Any CPU.ActiveCfg = Release|Win32
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Release|Mixed Platforms.ActiveCfg = Release|Win32
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Release|Mixed Platforms.Build.0 = Release|Win32
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Release|Win32.ActiveCfg = Release|Win32
-		{5D485D32-3B9F-4287-AB24-C8DA5B89F537}.Release|Win32.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/mcs/mcs/decl.cs
+++ b/mcs/mcs/decl.cs
@@ -292,7 +292,13 @@ namespace Mono.CSharp {
 		/// <value>The type of the file.</value>
 		public virtual bool PsExtended { 
 			get {
-				return member_name.Location.SourceFile != null ? member_name.Location.SourceFile.PsExtended : false;
+				// member_name will be null if we are running in the repl;
+				// TODO: Determine if REPL should allow Extended PlayScript language, 
+				// for now to run Tamarin tests, only ActionScript
+				if (member_name != null)
+					return member_name.Location.SourceFile != null ? member_name.Location.SourceFile.PsExtended : false;
+				else
+					return false;
 			}
 		}
 

--- a/mcs/mcs/eval.cs
+++ b/mcs/mcs/eval.cs
@@ -20,6 +20,8 @@ using System.Reflection.Emit;
 using System.IO;
 using System.Text;
 using System.Linq;
+using Mono.CSharp;
+using Mono.PlayScript;
 
 namespace Mono.CSharp
 {
@@ -231,8 +233,11 @@ namespace Mono.CSharp
 				}
 
 				bool partial_input;
+#if !PLAYSCRIPT_REPL
 				CSharpParser parser = ParseString (ParseMode.Silent, input, out partial_input);
-
+#else
+				PlayScriptParser parser = ParseString (ParseMode.Silent, input, out partial_input);
+#endif
 				// Terse mode, try to provide the trailing semicolon automatically.
 				if (parser == null && Terse && partial_input){
 					bool ignore;
@@ -366,7 +371,12 @@ namespace Mono.CSharp
 					Init ();
 				
 				bool partial_input;
+#if !PLAYSCRIPT_REPL
 				CSharpParser parser = ParseString (ParseMode.GetCompletions, input, out partial_input);
+#else
+				var parser = ParseString (ParseMode.GetCompletions, input, out partial_input);
+				parser.parsing_playscript = source_file.PsExtended;
+#endif
 				if (parser == null){
 					return null;
 				}
@@ -564,7 +574,12 @@ namespace Mono.CSharp
 		// @partial_input: if @silent is true, then it returns whether the
 		// parsed expression was partial, and more data is needed
 		//
+		//CSharpParser ParseString (ParseMode mode, string input, out bool partial_input)
+#if !PLAYSCRIPT_REPL
 		CSharpParser ParseString (ParseMode mode, string input, out bool partial_input)
+#else
+		PlayScriptParser ParseString (ParseMode mode, string input, out bool partial_input)
+#endif
 		{
 			partial_input = false;
 			Reset ();
@@ -591,8 +606,13 @@ namespace Mono.CSharp
 			seekable.Position = 0;
 
 			source_file.DeclarationFound = false;
-			CSharpParser parser = new CSharpParser (seekable, source_file, new ParserSession ());
-
+			var session = new ParserSession ();
+#if !PLAYSCRIPT_REPL
+			CSharpParser parser = new CSharpParser (seekable, source_file, session);
+#else
+			var parser = new PlayScriptParser (seekable, source_file, session);
+			parser.parsing_playscript = source_file.PsExtended;
+#endif
 			if (kind == InputKind.StatementOrExpression){
 				parser.Lexer.putback_char = Tokenizer.EvalStatementParserCharacter;
 				parser.Lexer.parsing_block++;
@@ -611,6 +631,10 @@ namespace Mono.CSharp
 
 			try {
 				parser.parse ();
+				// PlayScript needs to add generated code after parsing.
+				if (ctx.Settings.PsOnlyMode) {
+					Mono.PlayScript.CodeGenerator.GenerateCode(module, session, ctx.Report);
+				}
 			} finally {
 				if (ctx.Report.Errors != 0){
 					if (mode != ParseMode.ReportErrors  && parser.UnexpectedEOF)

--- a/mcs/mcs/ps-tokenizer.cs
+++ b/mcs/mcs/ps-tokenizer.cs
@@ -538,7 +538,12 @@ namespace Mono.PlayScript
 		public Tokenizer (SeekableStreamReader input, CompilationSourceFile file, ParserSession session)
 		{
 			this.source_file = file;
-			this.parsing_playscript = file.SourceFile.PsExtended;
+			// SourceFile will be null if we are running in the repl;
+			// TODO: Determine if REPL should allow Extended PlayScript language, 
+			// for now to run Tamarin tests, only ActionScript
+			if (file.SourceFile != null) {
+				this.parsing_playscript = file.SourceFile.PsExtended;
+			}
 			this.context = file.Compiler;
 			this.current_source = file.SourceFile;
 			this.identifiers = session.Identifiers;

--- a/mcs/mcs/settings.cs
+++ b/mcs/mcs/settings.cs
@@ -251,6 +251,12 @@ namespace Mono.CSharp {
 		public bool PsStrictMode = true;
 
 		//
+		// Whether to enable PlayScript compiler only mode. Defaults to false.
+		//
+
+		public bool PsOnlyMode = false;
+
+		//
 		// Inlining mode for source level inliner (none, explicit, any)
 		//
 
@@ -1168,8 +1174,16 @@ namespace Mono.CSharp {
 			case "/psstrict+":
 				settings.PsStrictMode = true;
 				return ParseResult.Success;
+                    
+            case "/psonlymode-":
+				settings.PsOnlyMode = false;
+                return ParseResult.Success;
 
-			case "/warnaserror":
+            case "/psonlymode+":
+				settings.PsOnlyMode = true;
+                return ParseResult.Success;
+
+				case "/warnaserror":
 			case "/warnaserror+":
 				if (value.Length == 0) {
 					settings.WarningsAreErrors = true;

--- a/mcs/tools/Makefile
+++ b/mcs/tools/Makefile
@@ -18,6 +18,7 @@ per_profile_dirs = \
 net_4_0_dirs := \
 	$(per_profile_dirs) \
 	csharp		\
+	playshell	\
 	corcompare	\
 	compiler-tester	\
 	mono-xmltool	\

--- a/mcs/tools/playshell/Makefile
+++ b/mcs/tools/playshell/Makefile
@@ -1,0 +1,25 @@
+thisdir = tools/playshell
+SUBDIRS = 
+mono_sourcelibs_DIR  = $(DESTDIR)$(mono_libdir)/mono-source-libs
+
+include ../../build/rules.make
+
+// 3021: CLS attribute not needed since assembly is not CLS compliant
+NOWARNS = -nowarn:3021
+LOCAL_MCS_FLAGS = -r:$(topdir)/class/lib/$(PROFILE)/Mono.PlayScript.dll -r:$(topdir)/class/lib/$(PROFILE)/Mono.Posix.dll -r:Mono.Management.dll -unsafe $(NOWARNS)
+LIB_MCS_FLAGS += -d:PLAYSCRIPT_REPL
+
+PROGRAM = playshell.exe
+
+DISTFILES = repl.txt
+
+CLEAN_FILES = playshell.exe *.mdb
+
+include ../../build/executable.make
+
+install-local: install-source
+
+install-source:
+	-$(MKINSTALLDIRS) $(mono_sourcelibs_DIR)
+	$(INSTALL) -m 644 getline.cs $(mono_sourcelibs_DIR)
+

--- a/mcs/tools/playshell/PlayShell.csproj
+++ b/mcs/tools/playshell/PlayShell.csproj
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0831DD4E-B428-4D6C-90B1-2206DBD4F92F}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>csharp</RootNamespace>
+    <AssemblyName>playsharp</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <UpgradeBackupLocation />
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
+    <ReleaseVersion>1.0</ReleaseVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;ON_DOTNET_NO;PLAYSCRIPT_REPL;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Externalconsole>true</Externalconsole>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;PLAYSCRIPT_REPL;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Mono.Management" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\class\corlib\Mono\DataConverter.cs">
+      <Link>DataConverter.cs</Link>
+    </Compile>
+    <Compile Include="getline.cs" />
+    <Compile Include="repl.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
+      <Visible>False</Visible>
+      <ProductName>Windows Installer 3.1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\class\Mono.PlayScript\Mono.PlayScript.csproj">
+      <Project>{D9F458AE-7290-4246-8E89-967D41C838CF}</Project>
+      <Name>Mono.PlayScript</Name>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/mcs/tools/playshell/PlayShell.sln
+++ b/mcs/tools/playshell/PlayShell.sln
@@ -1,0 +1,39 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlayShell", "PlayShell.csproj", "{0831DD4E-B428-4D6C-90B1-2206DBD4F92F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.PlayScript", "..\..\class\Mono.PlayScript\Mono.PlayScript.csproj", "{D9F458AE-7290-4246-8E89-967D41C838CF}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0831DD4E-B428-4D6C-90B1-2206DBD4F92F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0831DD4E-B428-4D6C-90B1-2206DBD4F92F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0831DD4E-B428-4D6C-90B1-2206DBD4F92F}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{0831DD4E-B428-4D6C-90B1-2206DBD4F92F}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{D9F458AE-7290-4246-8E89-967D41C838CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9F458AE-7290-4246-8E89-967D41C838CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9F458AE-7290-4246-8E89-967D41C838CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9F458AE-7290-4246-8E89-967D41C838CF}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		Policies = $0
+		$0.TextStylePolicy = $1
+		$1.TabsToSpaces = False
+		$1.inheritsSet = VisualStudio
+		$1.inheritsScope = text/plain
+		$1.scope = text/x-csharp
+		$0.CSharpFormattingPolicy = $2
+		$2.inheritsSet = Mono
+		$2.inheritsScope = text/x-csharp
+		$2.scope = text/x-csharp
+		version = 1.0
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/mcs/tools/playshell/getline.cs
+++ b/mcs/tools/playshell/getline.cs
@@ -1,0 +1,1086 @@
+//
+// getline.cs: A command line editor
+//
+// Authors:
+//   Miguel de Icaza (miguel@novell.com)
+//
+// Copyright 2008 Novell, Inc.
+//
+// Dual-licensed under the terms of the MIT X11 license or the
+// Apache License 2.0
+//
+// USE -define:DEMO to build this as a standalone file and test it
+//
+// TODO:
+//    Enter an error (a = 1);  Notice how the prompt is in the wrong line
+//		This is caused by Stderr not being tracked by System.Console.
+//    Completion support
+//    Why is Thread.Interrupt not working?   Currently I resort to Abort which is too much.
+//
+// Limitations in System.Console:
+//    Console needs SIGWINCH support of some sort
+//    Console needs a way of updating its position after things have been written
+//    behind its back (P/Invoke puts for example).
+//    System.Console needs to get the DELETE character, and report accordingly.
+//
+
+using System;
+using System.Text;
+using System.IO;
+using System.Threading;
+using System.Reflection;
+
+namespace Mono.Terminal {
+
+	public class LineEditor {
+
+		public class Completion {
+			public string [] Result;
+			public string Prefix;
+
+			public Completion (string prefix, string [] result)
+			{
+				Prefix = prefix;
+				Result = result;
+			}
+		}
+		
+		public delegate Completion AutoCompleteHandler (string text, int pos);
+		
+		//static StreamWriter log;
+		
+		// The text being edited.
+		StringBuilder text;
+
+		// The text as it is rendered (replaces (char)1 with ^A on display for example).
+		StringBuilder rendered_text;
+
+		// The prompt specified, and the prompt shown to the user.
+		string prompt;
+		string shown_prompt;
+		
+		// The current cursor position, indexes into "text", for an index
+		// into rendered_text, use TextToRenderPos
+		int cursor;
+
+		// The row where we started displaying data.
+		int home_row;
+
+		// The maximum length that has been displayed on the screen
+		int max_rendered;
+
+		// If we are done editing, this breaks the interactive loop
+		bool done = false;
+
+		// The thread where the Editing started taking place
+		Thread edit_thread;
+
+		// Our object that tracks history
+		History history;
+
+		// The contents of the kill buffer (cut/paste in Emacs parlance)
+		string kill_buffer = "";
+
+		// The string being searched for
+		string search;
+		string last_search;
+
+		// whether we are searching (-1= reverse; 0 = no; 1 = forward)
+		int searching;
+
+		// The position where we found the match.
+		int match_at;
+		
+		// Used to implement the Kill semantics (multiple Alt-Ds accumulate)
+		KeyHandler last_handler;
+		
+		delegate void KeyHandler ();
+		
+		struct Handler {
+			public ConsoleKeyInfo CKI;
+			public KeyHandler KeyHandler;
+
+			public Handler (ConsoleKey key, KeyHandler h)
+			{
+				CKI = new ConsoleKeyInfo ((char) 0, key, false, false, false);
+				KeyHandler = h;
+			}
+
+			public Handler (char c, KeyHandler h)
+			{
+				KeyHandler = h;
+				// Use the "Zoom" as a flag that we only have a character.
+				CKI = new ConsoleKeyInfo (c, ConsoleKey.Zoom, false, false, false);
+			}
+
+			public Handler (ConsoleKeyInfo cki, KeyHandler h)
+			{
+				CKI = cki;
+				KeyHandler = h;
+			}
+			
+			public static Handler Control (char c, KeyHandler h)
+			{
+				return new Handler ((char) (c - 'A' + 1), h);
+			}
+
+			public static Handler Alt (char c, ConsoleKey k, KeyHandler h)
+			{
+				ConsoleKeyInfo cki = new ConsoleKeyInfo ((char) c, k, false, true, false);
+				return new Handler (cki, h);
+			}
+		}
+
+		/// <summary>
+		///   Invoked when the user requests auto-completion using the tab character
+		/// </summary>
+		/// <remarks>
+		///    The result is null for no values found, an array with a single
+		///    string, in that case the string should be the text to be inserted
+		///    for example if the word at pos is "T", the result for a completion
+		///    of "ToString" should be "oString", not "ToString".
+		///
+		///    When there are multiple results, the result should be the full
+		///    text
+		/// </remarks>
+		public AutoCompleteHandler AutoCompleteEvent;
+		
+		static Handler [] handlers;
+
+		public LineEditor (string name) : this (name, 10) { }
+		
+		public LineEditor (string name, int histsize)
+		{
+			handlers = new Handler [] {
+				new Handler (ConsoleKey.Home,       CmdHome),
+				new Handler (ConsoleKey.End,        CmdEnd),
+				new Handler (ConsoleKey.LeftArrow,  CmdLeft),
+				new Handler (ConsoleKey.RightArrow, CmdRight),
+				new Handler (ConsoleKey.UpArrow,    CmdHistoryPrev),
+				new Handler (ConsoleKey.DownArrow,  CmdHistoryNext),
+				new Handler (ConsoleKey.Enter,      CmdDone),
+				new Handler (ConsoleKey.Backspace,  CmdBackspace),
+				new Handler (ConsoleKey.Delete,     CmdDeleteChar),
+				new Handler (ConsoleKey.Tab,        CmdTabOrComplete),
+				
+				// Emacs keys
+				Handler.Control ('A', CmdHome),
+				Handler.Control ('E', CmdEnd),
+				Handler.Control ('B', CmdLeft),
+				Handler.Control ('F', CmdRight),
+				Handler.Control ('P', CmdHistoryPrev),
+				Handler.Control ('N', CmdHistoryNext),
+				Handler.Control ('K', CmdKillToEOF),
+				Handler.Control ('Y', CmdYank),
+				Handler.Control ('D', CmdDeleteChar),
+				Handler.Control ('L', CmdRefresh),
+				Handler.Control ('R', CmdReverseSearch),
+				Handler.Control ('G', delegate {} ),
+				Handler.Alt ('B', ConsoleKey.B, CmdBackwardWord),
+				Handler.Alt ('F', ConsoleKey.F, CmdForwardWord),
+				
+				Handler.Alt ('D', ConsoleKey.D, CmdDeleteWord),
+				Handler.Alt ((char) 8, ConsoleKey.Backspace, CmdDeleteBackword),
+				
+				// DEBUG
+				//Handler.Control ('T', CmdDebug),
+
+				// quote
+				Handler.Control ('Q', delegate { HandleChar (Console.ReadKey (true).KeyChar); })
+			};
+
+			rendered_text = new StringBuilder ();
+			text = new StringBuilder ();
+
+			history = new History (name, histsize);
+			
+			//if (File.Exists ("log"))File.Delete ("log");
+			//log = File.CreateText ("log"); 
+		}
+
+		void CmdDebug ()
+		{
+			history.Dump ();
+			Console.WriteLine ();
+			Render ();
+		}
+
+		void Render ()
+		{
+			Console.Write (shown_prompt);
+			Console.Write (rendered_text);
+
+			int max = System.Math.Max (rendered_text.Length + shown_prompt.Length, max_rendered);
+			
+			for (int i = rendered_text.Length + shown_prompt.Length; i < max_rendered; i++)
+				Console.Write (' ');
+			max_rendered = shown_prompt.Length + rendered_text.Length;
+
+			// Write one more to ensure that we always wrap around properly if we are at the
+			// end of a line.
+			Console.Write (' ');
+
+			UpdateHomeRow (max);
+		}
+
+		void UpdateHomeRow (int screenpos)
+		{
+			int lines = 1 + (screenpos / Console.WindowWidth);
+
+			home_row = Console.CursorTop - (lines - 1);
+			if (home_row < 0)
+				home_row = 0;
+		}
+		
+
+		void RenderFrom (int pos)
+		{
+			int rpos = TextToRenderPos (pos);
+			int i;
+			
+			for (i = rpos; i < rendered_text.Length; i++)
+				Console.Write (rendered_text [i]);
+
+			if ((shown_prompt.Length + rendered_text.Length) > max_rendered)
+				max_rendered = shown_prompt.Length + rendered_text.Length;
+			else {
+				int max_extra = max_rendered - shown_prompt.Length;
+				for (; i < max_extra; i++)
+					Console.Write (' ');
+			}
+		}
+
+		void ComputeRendered ()
+		{
+			rendered_text.Length = 0;
+
+			for (int i = 0; i < text.Length; i++){
+				int c = (int) text [i];
+				if (c < 26){
+					if (c == '\t')
+						rendered_text.Append ("    ");
+					else {
+						rendered_text.Append ('^');
+						rendered_text.Append ((char) (c + (int) 'A' - 1));
+					}
+				} else
+					rendered_text.Append ((char)c);
+			}
+		}
+
+		int TextToRenderPos (int pos)
+		{
+			int p = 0;
+
+			for (int i = 0; i < pos; i++){
+				int c;
+
+				c = (int) text [i];
+				
+				if (c < 26){
+					if (c == 9)
+						p += 4;
+					else
+						p += 2;
+				} else
+					p++;
+			}
+
+			return p;
+		}
+
+		int TextToScreenPos (int pos)
+		{
+			return shown_prompt.Length + TextToRenderPos (pos);
+		}
+		
+		string Prompt {
+			get { return prompt; }
+			set { prompt = value; }
+		}
+
+		int LineCount {
+			get {
+				return (shown_prompt.Length + rendered_text.Length)/Console.WindowWidth;
+			}
+		}
+		
+		void ForceCursor (int newpos)
+		{
+			cursor = newpos;
+
+			int actual_pos = shown_prompt.Length + TextToRenderPos (cursor);
+			int row = home_row + (actual_pos/Console.WindowWidth);
+			int col = actual_pos % Console.WindowWidth;
+
+			if (row >= Console.BufferHeight)
+				row = Console.BufferHeight-1;
+			Console.SetCursorPosition (col, row);
+			
+			//log.WriteLine ("Going to cursor={0} row={1} col={2} actual={3} prompt={4} ttr={5} old={6}", newpos, row, col, actual_pos, prompt.Length, TextToRenderPos (cursor), cursor);
+			//log.Flush ();
+		}
+
+		void UpdateCursor (int newpos)
+		{
+			if (cursor == newpos)
+				return;
+
+			ForceCursor (newpos);
+		}
+
+		void InsertChar (char c)
+		{
+			int prev_lines = LineCount;
+			text = text.Insert (cursor, c);
+			ComputeRendered ();
+			if (prev_lines != LineCount){
+
+				Console.SetCursorPosition (0, home_row);
+				Render ();
+				ForceCursor (++cursor);
+			} else {
+				RenderFrom (cursor);
+				ForceCursor (++cursor);
+				UpdateHomeRow (TextToScreenPos (cursor));
+			}
+		}
+
+		//
+		// Commands
+		//
+		void CmdDone ()
+		{
+			done = true;
+		}
+
+		void CmdTabOrComplete ()
+		{
+			bool complete = false;
+
+			if (AutoCompleteEvent != null){
+				if (TabAtStartCompletes)
+					complete = true;
+				else {
+					for (int i = 0; i < cursor; i++){
+						if (!Char.IsWhiteSpace (text [i])){
+							complete = true;
+							break;
+						}
+					}
+				}
+
+				if (complete){
+					Completion completion = AutoCompleteEvent (text.ToString (), cursor);
+					string [] completions = completion.Result;
+					if (completions == null)
+						return;
+					
+					int ncompletions = completions.Length;
+					if (ncompletions == 0)
+						return;
+					
+					if (completions.Length == 1){
+						InsertTextAtCursor (completions [0]);
+					} else {
+						int last = -1;
+						
+						for (int p = 0; p < completions [0].Length; p++){
+							char c = completions [0][p];
+
+
+							for (int i = 1; i < ncompletions; i++){
+								if (completions [i].Length < p)
+									goto mismatch;
+							
+								if (completions [i][p] != c){
+									goto mismatch;
+								}
+							}
+							last = p;
+						}
+					mismatch:
+						if (last != -1){
+							InsertTextAtCursor (completions [0].Substring (0, last+1));
+						}
+						Console.WriteLine ();
+						foreach (string s in completions){
+							Console.Write (completion.Prefix);
+							Console.Write (s);
+							Console.Write (' ');
+						}
+						Console.WriteLine ();
+						Render ();
+						ForceCursor (cursor);
+					}
+				} else
+					HandleChar ('\t');
+			} else
+				HandleChar ('t');
+		}
+		
+		void CmdHome ()
+		{
+			UpdateCursor (0);
+		}
+
+		void CmdEnd ()
+		{
+			UpdateCursor (text.Length);
+		}
+		
+		void CmdLeft ()
+		{
+			if (cursor == 0)
+				return;
+
+			UpdateCursor (cursor-1);
+		}
+
+		void CmdBackwardWord ()
+		{
+			int p = WordBackward (cursor);
+			if (p == -1)
+				return;
+			UpdateCursor (p);
+		}
+
+		void CmdForwardWord ()
+		{
+			int p = WordForward (cursor);
+			if (p == -1)
+				return;
+			UpdateCursor (p);
+		}
+
+		void CmdRight ()
+		{
+			if (cursor == text.Length)
+				return;
+
+			UpdateCursor (cursor+1);
+		}
+
+		void RenderAfter (int p)
+		{
+			ForceCursor (p);
+			RenderFrom (p);
+			ForceCursor (cursor);
+		}
+		
+		void CmdBackspace ()
+		{
+			if (cursor == 0)
+				return;
+
+			text.Remove (--cursor, 1);
+			ComputeRendered ();
+			RenderAfter (cursor);
+		}
+
+		void CmdDeleteChar ()
+		{
+			// If there is no input, this behaves like EOF
+			if (text.Length == 0){
+				done = true;
+				text = null;
+				Console.WriteLine ();
+				return;
+			}
+			
+			if (cursor == text.Length)
+				return;
+			text.Remove (cursor, 1);
+			ComputeRendered ();
+			RenderAfter (cursor);
+		}
+
+		int WordForward (int p)
+		{
+			if (p >= text.Length)
+				return -1;
+
+			int i = p;
+			if (Char.IsPunctuation (text [p]) || Char.IsSymbol (text [p]) || Char.IsWhiteSpace (text[p])){
+				for (; i < text.Length; i++){
+					if (Char.IsLetterOrDigit (text [i]))
+					    break;
+				}
+				for (; i < text.Length; i++){
+					if (!Char.IsLetterOrDigit (text [i]))
+					    break;
+				}
+			} else {
+				for (; i < text.Length; i++){
+					if (!Char.IsLetterOrDigit (text [i]))
+					    break;
+				}
+			}
+			if (i != p)
+				return i;
+			return -1;
+		}
+
+		int WordBackward (int p)
+		{
+			if (p == 0)
+				return -1;
+
+			int i = p-1;
+			if (i == 0)
+				return 0;
+			
+			if (Char.IsPunctuation (text [i]) || Char.IsSymbol (text [i]) || Char.IsWhiteSpace (text[i])){
+				for (; i >= 0; i--){
+					if (Char.IsLetterOrDigit (text [i]))
+						break;
+				}
+				for (; i >= 0; i--){
+					if (!Char.IsLetterOrDigit (text[i]))
+						break;
+				}
+			} else {
+				for (; i >= 0; i--){
+					if (!Char.IsLetterOrDigit (text [i]))
+						break;
+				}
+			}
+			i++;
+			
+			if (i != p)
+				return i;
+
+			return -1;
+		}
+		
+		void CmdDeleteWord ()
+		{
+			int pos = WordForward (cursor);
+
+			if (pos == -1)
+				return;
+
+			string k = text.ToString (cursor, pos-cursor);
+			
+			if (last_handler == CmdDeleteWord)
+				kill_buffer = kill_buffer + k;
+			else
+				kill_buffer = k;
+			
+			text.Remove (cursor, pos-cursor);
+			ComputeRendered ();
+			RenderAfter (cursor);
+		}
+		
+		void CmdDeleteBackword ()
+		{
+			int pos = WordBackward (cursor);
+			if (pos == -1)
+				return;
+
+			string k = text.ToString (pos, cursor-pos);
+			
+			if (last_handler == CmdDeleteBackword)
+				kill_buffer = k + kill_buffer;
+			else
+				kill_buffer = k;
+			
+			text.Remove (pos, cursor-pos);
+			ComputeRendered ();
+			RenderAfter (pos);
+		}
+		
+		//
+		// Adds the current line to the history if needed
+		//
+		void HistoryUpdateLine ()
+		{
+			history.Update (text.ToString ());
+		}
+		
+		void CmdHistoryPrev ()
+		{
+			if (!history.PreviousAvailable ())
+				return;
+
+			HistoryUpdateLine ();
+			
+			SetText (history.Previous ());
+		}
+
+		void CmdHistoryNext ()
+		{
+			if (!history.NextAvailable())
+				return;
+
+			history.Update (text.ToString ());
+			SetText (history.Next ());
+			
+		}
+
+		void CmdKillToEOF ()
+		{
+			kill_buffer = text.ToString (cursor, text.Length-cursor);
+			text.Length = cursor;
+			ComputeRendered ();
+			RenderAfter (cursor);
+		}
+
+		void CmdYank ()
+		{
+			InsertTextAtCursor (kill_buffer);
+		}
+
+		void InsertTextAtCursor (string str)
+		{
+			int prev_lines = LineCount;
+			text.Insert (cursor, str);
+			ComputeRendered ();
+			if (prev_lines != LineCount){
+				Console.SetCursorPosition (0, home_row);
+				Render ();
+				cursor += str.Length;
+				ForceCursor (cursor);
+			} else {
+				RenderFrom (cursor);
+				cursor += str.Length;
+				ForceCursor (cursor);
+				UpdateHomeRow (TextToScreenPos (cursor));
+			}
+		}
+		
+		void SetSearchPrompt (string s)
+		{
+			SetPrompt ("(reverse-i-search)`" + s + "': ");
+		}
+
+		void ReverseSearch ()
+		{
+			int p;
+
+			if (cursor == text.Length){
+				// The cursor is at the end of the string
+				
+				p = text.ToString ().LastIndexOf (search);
+				if (p != -1){
+					match_at = p;
+					cursor = p;
+					ForceCursor (cursor);
+					return;
+				}
+			} else {
+				// The cursor is somewhere in the middle of the string
+				int start = (cursor == match_at) ? cursor - 1 : cursor;
+				if (start != -1){
+					p = text.ToString ().LastIndexOf (search, start);
+					if (p != -1){
+						match_at = p;
+						cursor = p;
+						ForceCursor (cursor);
+						return;
+					}
+				}
+			}
+
+			// Need to search backwards in history
+			HistoryUpdateLine ();
+			string s = history.SearchBackward (search);
+			if (s != null){
+				match_at = -1;
+				SetText (s);
+				ReverseSearch ();
+			}
+		}
+		
+		void CmdReverseSearch ()
+		{
+			if (searching == 0){
+				match_at = -1;
+				last_search = search;
+				searching = -1;
+				search = "";
+				SetSearchPrompt ("");
+			} else {
+				if (search == ""){
+					if (last_search != "" && last_search != null){
+						search = last_search;
+						SetSearchPrompt (search);
+
+						ReverseSearch ();
+					}
+					return;
+				}
+				ReverseSearch ();
+			} 
+		}
+
+		void SearchAppend (char c)
+		{
+			search = search + c;
+			SetSearchPrompt (search);
+
+			//
+			// If the new typed data still matches the current text, stay here
+			//
+			if (cursor < text.Length){
+				string r = text.ToString (cursor, text.Length - cursor);
+				if (r.StartsWith (search))
+					return;
+			}
+
+			ReverseSearch ();
+		}
+		
+		void CmdRefresh ()
+		{
+			Console.Clear ();
+			max_rendered = 0;
+			Render ();
+			ForceCursor (cursor);
+		}
+
+		void InterruptEdit (object sender, ConsoleCancelEventArgs a)
+		{
+			// Do not abort our program:
+			a.Cancel = true;
+
+			// Interrupt the editor
+			edit_thread.Abort();
+		}
+
+		void HandleChar (char c)
+		{
+			if (searching != 0)
+				SearchAppend (c);
+			else
+				InsertChar (c);
+		}
+
+		void EditLoop ()
+		{
+			ConsoleKeyInfo cki;
+
+			while (!done){
+				ConsoleModifiers mod;
+				
+				cki = Console.ReadKey (true);
+				if (cki.Key == ConsoleKey.Escape){
+					cki = Console.ReadKey (true);
+
+					mod = ConsoleModifiers.Alt;
+				} else
+					mod = cki.Modifiers;
+				
+				bool handled = false;
+
+				foreach (Handler handler in handlers){
+					ConsoleKeyInfo t = handler.CKI;
+
+					if (t.Key == cki.Key && t.Modifiers == mod){
+						handled = true;
+						handler.KeyHandler ();
+						last_handler = handler.KeyHandler;
+						break;
+					} else if (t.KeyChar == cki.KeyChar && t.Key == ConsoleKey.Zoom){
+						handled = true;
+						handler.KeyHandler ();
+						last_handler = handler.KeyHandler;
+						break;
+					}
+				}
+				if (handled){
+					if (searching != 0){
+						if (last_handler != CmdReverseSearch){
+							searching = 0;
+							SetPrompt (prompt);
+						}
+					}
+					continue;
+				}
+
+				if (cki.KeyChar != (char) 0)
+					HandleChar (cki.KeyChar);
+			} 
+		}
+
+		void InitText (string initial)
+		{
+			text = new StringBuilder (initial);
+			ComputeRendered ();
+			cursor = text.Length;
+			Render ();
+			ForceCursor (cursor);
+		}
+
+		void SetText (string newtext)
+		{
+			Console.SetCursorPosition (0, home_row);
+			InitText (newtext);
+		}
+
+		void SetPrompt (string newprompt)
+		{
+			shown_prompt = newprompt;
+			Console.SetCursorPosition (0, home_row);
+			Render ();
+			ForceCursor (cursor);
+		}
+		
+		public string Edit (string prompt, string initial)
+		{
+			edit_thread = Thread.CurrentThread;
+			searching = 0;
+			Console.CancelKeyPress += InterruptEdit;
+			
+			done = false;
+			history.CursorToEnd ();
+			max_rendered = 0;
+			
+			Prompt = prompt;
+			shown_prompt = prompt;
+			InitText (initial);
+			history.Append (initial);
+
+			do {
+				try {
+					EditLoop ();
+				} catch (ThreadAbortException){
+					searching = 0;
+					Thread.ResetAbort ();
+					Console.WriteLine ();
+					SetPrompt (prompt);
+					SetText ("");
+				}
+			} while (!done);
+			Console.WriteLine ();
+			
+			Console.CancelKeyPress -= InterruptEdit;
+
+			if (text == null){
+				history.Close ();
+				return null;
+			}
+
+			string result = text.ToString ();
+			if (result != "")
+				history.Accept (result);
+			else
+				history.RemoveLast ();
+
+			return result;
+		}
+		
+		public void SaveHistory ()
+		{
+			if (history != null) {
+				history.Close ();
+			}
+		}
+
+		public bool TabAtStartCompletes { get; set; }
+			
+		//
+		// Emulates the bash-like behavior, where edits done to the
+		// history are recorded
+		//
+		class History {
+			string [] history;
+			int head, tail;
+			int cursor, count;
+			string histfile;
+			
+			public History (string app, int size)
+			{
+				if (size < 1)
+					throw new ArgumentException ("size");
+
+				if (app != null){
+					string dir = Environment.GetFolderPath (Environment.SpecialFolder.ApplicationData);
+					//Console.WriteLine (dir);
+					if (!Directory.Exists (dir)){
+						try {
+							Directory.CreateDirectory (dir);
+						} catch {
+							app = null;
+						}
+					}
+					if (app != null)
+						histfile = Path.Combine (dir, app) + ".history";
+				}
+				
+				history = new string [size];
+				head = tail = cursor = 0;
+
+				if (File.Exists (histfile)){
+					using (StreamReader sr = File.OpenText (histfile)){
+						string line;
+						
+						while ((line = sr.ReadLine ()) != null){
+							if (line != "")
+								Append (line);
+						}
+					}
+				}
+			}
+
+			public void Close ()
+			{
+				if (histfile == null)
+					return;
+
+				try {
+					using (StreamWriter sw = File.CreateText (histfile)){
+						int start = (count == history.Length) ? head : tail;
+						for (int i = start; i < start+count; i++){
+							int p = i % history.Length;
+							sw.WriteLine (history [p]);
+						}
+					}
+				} catch {
+					// ignore
+				}
+			}
+			
+			//
+			// Appends a value to the history
+			//
+			public void Append (string s)
+			{
+				//Console.WriteLine ("APPENDING {0} head={1} tail={2}", s, head, tail);
+				history [head] = s;
+				head = (head+1) % history.Length;
+				if (head == tail)
+					tail = (tail+1 % history.Length);
+				if (count != history.Length)
+					count++;
+				//Console.WriteLine ("DONE: head={1} tail={2}", s, head, tail);
+			}
+
+			//
+			// Updates the current cursor location with the string,
+			// to support editing of history items.   For the current
+			// line to participate, an Append must be done before.
+			//
+			public void Update (string s)
+			{
+				history [cursor] = s;
+			}
+
+			public void RemoveLast ()
+			{
+				head = head-1;
+				if (head < 0)
+					head = history.Length-1;
+			}
+			
+			public void Accept (string s)
+			{
+				int t = head-1;
+				if (t < 0)
+					t = history.Length-1;
+				
+				history [t] = s;
+			}
+			
+			public bool PreviousAvailable ()
+			{
+				//Console.WriteLine ("h={0} t={1} cursor={2}", head, tail, cursor);
+				if (count == 0)
+					return false;
+				int next = cursor-1;
+				if (next < 0)
+					next = count-1;
+
+				if (next == head)
+					return false;
+
+				return true;
+			}
+
+			public bool NextAvailable ()
+			{
+				if (count == 0)
+					return false;
+				int next = (cursor + 1) % history.Length;
+				if (next == head)
+					return false;
+				return true;
+			}
+			
+			
+			//
+			// Returns: a string with the previous line contents, or
+			// nul if there is no data in the history to move to.
+			//
+			public string Previous ()
+			{
+				if (!PreviousAvailable ())
+					return null;
+
+				cursor--;
+				if (cursor < 0)
+					cursor = history.Length - 1;
+
+				return history [cursor];
+			}
+
+			public string Next ()
+			{
+				if (!NextAvailable ())
+					return null;
+
+				cursor = (cursor + 1) % history.Length;
+				return history [cursor];
+			}
+
+			public void CursorToEnd ()
+			{
+				if (head == tail)
+					return;
+
+				cursor = head;
+			}
+
+			public void Dump ()
+			{
+				Console.WriteLine ("Head={0} Tail={1} Cursor={2} count={3}", head, tail, cursor, count);
+				for (int i = 0; i < history.Length;i++){
+					Console.WriteLine (" {0} {1}: {2}", i == cursor ? "==>" : "   ", i, history[i]);
+				}
+				//log.Flush ();
+			}
+
+			public string SearchBackward (string term)
+			{
+				for (int i = 0; i < count; i++){
+					int slot = cursor-i-1;
+					if (slot < 0)
+						slot = history.Length+slot;
+					if (slot >= history.Length)
+						slot = 0;
+					if (history [slot] != null && history [slot].IndexOf (term) != -1){
+						cursor = slot;
+						return history [slot];
+					}
+				}
+
+				return null;
+			}
+			
+		}
+	}
+
+#if DEMO
+	class Demo {
+		static void Main ()
+		{
+			LineEditor le = new LineEditor ("foo");
+			string s;
+			
+			while ((s = le.Edit ("shell> ", "")) != null){
+				Console.WriteLine ("----> [{0}]", s);
+			}
+		}
+	}
+#endif
+}

--- a/mcs/tools/playshell/playshell.exe.sources
+++ b/mcs/tools/playshell/playshell.exe.sources
@@ -1,0 +1,3 @@
+../../class/corlib/Mono/DataConverter.cs
+repl.cs
+getline.cs

--- a/mcs/tools/playshell/repl.cs
+++ b/mcs/tools/playshell/repl.cs
@@ -1,0 +1,808 @@
+//
+// repl.cs: Support for using the compiler in interactive mode (read-eval-print loop)
+//
+// Authors:
+//   Miguel de Icaza (miguel@gnome.org)
+//   SushiHangover/RobertN (http://github.com/susihhangover)
+//
+// Dual licensed under the terms of the MIT X11 or GNU GPL
+//
+// Copyright 2001, 2002, 2003 Ximian, Inc (http://www.ximian.com)
+// Copyright 2004, 2005, 2006, 2007, 2008 Novell, Inc
+// Copyright 2015 SushiHangover/RobertN (http://github.com/susihhangover)
+//
+// TODO:
+//   Do not print results in Evaluate, do that elsewhere in preparation for Eval refactoring.
+//   Driver.PartialReset should not reset the coretypes, nor the optional types, to avoid
+//      computing that on every call.
+//
+using System;
+using System.IO;
+using System.Text;
+using System.Collections;
+using System.Reflection;
+using System.Threading;
+using System.Net;
+using System.Net.Sockets;
+using System.Collections.Generic;
+
+using Mono.CSharp;
+using Mono.PlayScript;
+
+namespace Mono.PlayScript {
+
+	public class Driver {
+		public static string StartupEvalExpression;
+        #pragma warning disable 414
+		static int? attach;
+        #pragma warning restore 414
+		static string agent;
+        
+		static int Main (string [] args)
+		{
+            var cmd = new CommandLineParser (Console.Out);
+			cmd.UnknownOptionHandler += HandleExtraArguments;
+
+			// Enable unsafe code by default
+			var settings = new CompilerSettings () {
+				Unsafe = true,
+                PsStrictMode = false,
+				PsOnlyMode = true,
+			};
+			settings.VerboseParserFlag++;
+
+			if (!cmd.ParseArguments (settings, args))
+				return 1;
+
+			var startup_files = new string [settings.SourceFiles.Count];
+			int i = 0;
+			foreach (var source in settings.SourceFiles)
+				startup_files [i++] = source.FullPathName;
+			settings.SourceFiles.Clear ();
+
+			TextWriter agent_stderr = null;
+			ReportPrinter printer;
+			if (agent != null) {
+				agent_stderr = new StringWriter ();
+				printer = new StreamReportPrinter (agent_stderr);
+			} else {
+				printer = new ConsoleReportPrinter ();
+			}
+
+			var eval = new Evaluator (new CompilerContext (settings, printer));
+
+			eval.InteractiveBaseClass = typeof (InteractiveBaseShell);
+			eval.DescribeTypeExpressions = true;
+			eval.WaitOnTask = true;
+
+			PlaySharpShell shell;
+#if !ON_DOTNET
+			if (attach.HasValue) {
+				shell = new ClientPlaySharpShell (eval, attach.Value);
+			} else if (agent != null) {
+				new CSharpAgent (eval, agent, agent_stderr).Run (startup_files);
+				return 0;
+			} else
+#endif
+			{
+				shell = new PlaySharpShell (eval);
+			}
+			return shell.Run (startup_files);
+		}
+
+		static int HandleExtraArguments (string [] args, int pos)
+		{
+			switch (args [pos]) {
+			case "-e":
+				if (pos + 1 < args.Length) {
+					StartupEvalExpression = args[pos + 1];
+					return pos + 1;
+				}
+				break;
+			case "--attach":
+				if (pos + 1 < args.Length) {
+					attach = Int32.Parse (args[1]);
+					return pos + 1;
+				}
+				break;
+			default:
+				if (args [pos].StartsWith ("--agent:")) {
+					agent = args[pos];
+					return pos + 1;
+				} else {
+					return -1;
+				}
+			}
+			return -1;
+		}
+		
+	}
+
+	public class InteractiveBaseShell : InteractiveBase {
+		static bool tab_at_start_completes;
+		
+		static InteractiveBaseShell ()
+		{
+			Prompt = "play>";
+			ContinuationPrompt = "|";
+			tab_at_start_completes = false;
+		}
+
+		internal static Mono.Terminal.LineEditor Editor;
+		
+		public static bool TabAtStartCompletes {
+			get {
+				return tab_at_start_completes;
+			}
+
+			set {
+				tab_at_start_completes = value;
+				if (Editor != null)
+					Editor.TabAtStartCompletes = value;
+			}
+		}
+
+		public static new string help {
+			get {
+				return InteractiveBase.help +
+					"  TabAtStartCompletes      - Whether tab will complete even on empty lines\n";
+			}
+		}
+	}
+	
+	public class PlaySharpShell {
+		static bool isatty = true, is_unix = false;
+		protected string [] startup_files;
+		
+		Mono.Terminal.LineEditor editor;
+		bool dumb;
+		readonly Evaluator evaluator;
+
+		public PlaySharpShell (Evaluator evaluator)
+		{
+			this.evaluator = evaluator;
+		}
+
+		protected virtual void ConsoleInterrupt (object sender, ConsoleCancelEventArgs a)
+		{
+			// Do not about our program
+			a.Cancel = true;
+
+			evaluator.Interrupt ();
+		}
+		
+		void SetupConsole ()
+		{
+			if (is_unix){
+				string term = Environment.GetEnvironmentVariable ("TERM");
+				dumb = term == "dumb" || term == null || isatty == false;
+			} else
+				dumb = false;
+			
+			editor = new Mono.Terminal.LineEditor ("play>", 300);
+			InteractiveBaseShell.Editor = editor;
+
+			editor.AutoCompleteEvent += delegate (string s, int pos){
+				string prefix = null;
+
+				string complete = s.Substring (0, pos);
+				
+				string [] completions = evaluator.GetCompletions (complete, out prefix);
+				
+				return new Mono.Terminal.LineEditor.Completion (prefix, completions);
+			};
+			
+#if false
+			//
+			// This is a sample of how completions sould be implemented.
+			//
+			editor.AutoCompleteEvent += delegate (string s, int pos){
+
+				// Single match: "Substring": Sub-string
+				if (s.EndsWith ("Sub")){
+					return new string [] { "string" };
+				}
+
+				// Multiple matches: "ToString" and "ToLower"
+				if (s.EndsWith ("T")){
+					return new string [] { "ToString", "ToLower" };
+				}
+				return null;
+			};
+#endif
+			
+			Console.CancelKeyPress += ConsoleInterrupt;
+		}
+
+		string GetLine (bool primary)
+		{
+			string prompt = primary ? InteractiveBase.Prompt : InteractiveBase.ContinuationPrompt;
+
+			if (dumb){
+				if (isatty)
+					Console.Write (prompt);
+
+				return Console.ReadLine ();
+			} else {
+				return editor.Edit (prompt, "");
+			}
+		}
+
+		delegate string ReadLiner (bool primary);
+
+		void InitializeUsing ()
+		{
+//			Evaluate ("using System; using System.Linq; using System.Collections.Generic; using System.Collections;");
+		}
+
+		void InitTerminal (bool show_banner)
+		{
+			int p = (int) Environment.OSVersion.Platform;
+			is_unix = (p == 4) || (p == 128);
+
+#if NET_4_5
+			isatty = !Console.IsInputRedirected && !Console.IsOutputRedirected;
+#else
+			isatty = true;
+#endif
+
+			// Work around, since Console is not accounting for
+			// cursor position when writing to Stderr.  It also
+			// has the undesirable side effect of making
+			// errors plain, with no coloring.
+//			Report.Stderr = Console.Out;
+			SetupConsole ();
+
+			if (isatty && show_banner)
+				Console.WriteLine ("Mono PlayScript Shell, type \"help;\" for help\n\nEnter statements below.");
+
+		}
+
+		void ExecuteSources (IEnumerable<string> sources, bool ignore_errors)
+		{
+			foreach (string file in sources){
+				try {
+					try {
+						bool first = true;
+			
+						using (System.IO.StreamReader r = System.IO.File.OpenText (file)){
+							ReadEvalPrintLoopWith (p => {
+								var line = r.ReadLine ();
+								if (first){
+									if (line.StartsWith ("#!"))
+										line = r.ReadLine ();
+									first = false;
+								}
+								return line;
+							});
+						}
+					} catch (FileNotFoundException){
+						Console.Error.WriteLine ("cs2001: Source file `{0}' not found", file);
+						return;
+					}
+				} catch {
+					if (!ignore_errors)
+						throw;
+				}
+			}
+		}
+		
+		protected virtual void LoadStartupFiles ()
+		{
+			string dir = Path.Combine (
+				Environment.GetFolderPath (Environment.SpecialFolder.ApplicationData),
+				"playsharp");
+			if (!Directory.Exists (dir))
+				return;
+
+			List<string> sources = new List<string> ();
+			List<string> libraries = new List<string> ();
+			
+			foreach (string file in System.IO.Directory.GetFiles (dir)){
+				string l = file.ToLower ();
+				
+				if (l.EndsWith (".cs"))
+					sources.Add (file);
+				else if (l.EndsWith (".dll"))
+					libraries.Add (file);
+			}
+
+			foreach (string file in libraries)
+				evaluator.LoadAssembly (file);
+
+			ExecuteSources (sources, true);
+		}
+
+		void ReadEvalPrintLoopWith (ReadLiner readline)
+		{
+			string expr = null;
+			while (!InteractiveBase.QuitRequested){
+				string input = readline (expr == null);
+				if (input == null)
+					return;
+
+				if (input == "")
+					continue;
+
+				expr = expr == null ? input : expr + "\n" + input;
+				
+				expr = Evaluate (expr);
+			}
+		}
+
+		public int ReadEvalPrintLoop ()
+		{
+			if (startup_files != null && startup_files.Length == 0)
+				InitTerminal (startup_files.Length == 0 && Driver.StartupEvalExpression == null);
+
+			InitializeUsing ();
+
+			LoadStartupFiles ();
+
+			if (startup_files != null && startup_files.Length != 0) {
+				ExecuteSources (startup_files, false);
+			} else {
+				if (Driver.StartupEvalExpression != null){
+					ReadEvalPrintLoopWith (p => {
+						var ret = Driver.StartupEvalExpression;
+						Driver.StartupEvalExpression = null;
+						return ret;
+						});
+				} else {
+					ReadEvalPrintLoopWith (GetLine);
+				}
+				
+				editor.SaveHistory ();
+			}
+
+			Console.CancelKeyPress -= ConsoleInterrupt;
+			
+			return 0;
+		}
+
+		protected virtual string Evaluate (string input)
+		{
+			bool result_set;
+			object result;
+
+			try {
+				input = evaluator.Evaluate (input, out result, out result_set);
+
+				if (result_set){
+					PrettyPrint (Console.Out, result);
+					Console.WriteLine ();
+				}
+			} catch (Exception e){
+				Console.WriteLine (e);
+				return null;
+			}
+			
+			return input;
+		}
+
+		static void p (TextWriter output, string s)
+		{
+			output.Write (s);
+		}
+
+		static string EscapeString (string s)
+		{
+			return s.Replace ("\"", "\\\"");
+		}
+		
+		static void EscapeChar (TextWriter output, char c)
+		{
+			if (c == '\''){
+				output.Write ("'\\''");
+				return;
+			}
+			if (c > 32){
+				output.Write ("'{0}'", c);
+				return;
+			}
+			switch (c){
+			case '\a':
+				output.Write ("'\\a'");
+				break;
+
+			case '\b':
+				output.Write ("'\\b'");
+				break;
+				
+			case '\n':
+				output.Write ("'\\n'");
+				break;
+				
+			case '\v':
+				output.Write ("'\\v'");
+				break;
+				
+			case '\r':
+				output.Write ("'\\r'");
+				break;
+				
+			case '\f':
+				output.Write ("'\\f'");
+				break;
+				
+			case '\t':
+				output.Write ("'\\t");
+				break;
+
+			default:
+				output.Write ("'\\x{0:x}", (int) c);
+				break;
+			}
+		}
+
+		// Some types (System.Json.JsonPrimitive) implement
+		// IEnumerator and yet, throw an exception when we
+		// try to use them, helper function to check for that
+		// condition
+		static internal bool WorksAsEnumerable (object obj)
+		{
+			IEnumerable enumerable = obj as IEnumerable;
+			if (enumerable != null){
+				try {
+					enumerable.GetEnumerator ();
+					return true;
+				} catch {
+					// nothing, we return false below
+				}
+			}
+			return false;
+		}
+		
+		internal static void PrettyPrint (TextWriter output, object result)
+		{
+			if (result == null){
+				p (output, "null");
+				return;
+			}
+			
+			if (result is Array){
+				Array a = (Array) result;
+				
+				p (output, "{ ");
+				int top = a.GetUpperBound (0);
+				for (int i = a.GetLowerBound (0); i <= top; i++){
+					PrettyPrint (output, a.GetValue (i));
+					if (i != top)
+						p (output, ", ");
+				}
+				p (output, " }");
+			} else if (result is bool){
+				if ((bool) result)
+					p (output, "true");
+				else
+					p (output, "false");
+			} else if (result is string){
+				p (output, String.Format ("\"{0}\"", EscapeString ((string)result)));
+			} else if (result is IDictionary){
+				IDictionary dict = (IDictionary) result;
+				int top = dict.Count, count = 0;
+				
+				p (output, "{");
+				foreach (DictionaryEntry entry in dict){
+					count++;
+					p (output, "{ ");
+					PrettyPrint (output, entry.Key);
+					p (output, ", ");
+					PrettyPrint (output, entry.Value);
+					if (count != top)
+						p (output, " }, ");
+					else
+						p (output, " }");
+				}
+				p (output, "}");
+			} else if (WorksAsEnumerable (result)) {
+				int i = 0;
+				p (output, "{ ");
+				foreach (object item in (IEnumerable) result) {
+					if (i++ != 0)
+						p (output, ", ");
+
+					PrettyPrint (output, item);
+				}
+				p (output, " }");
+			} else if (result is char) {
+				EscapeChar (output, (char) result);
+			} else {
+				p (output, result.ToString ());
+			}
+		}
+
+		public virtual int Run (string [] startup_files)
+		{
+			this.startup_files = startup_files;
+			return ReadEvalPrintLoop ();
+		}
+		
+	}
+
+#if !ON_DOTNET
+	//
+	// A shell connected to a PlaySharpAgent running in a remote process.
+	//  - maybe add 'class_name' and 'method_name' arguments to LoadAgent.
+	//  - Support Gtk and Winforms main loops if detected, this should
+	//    probably be done as a separate agent in a separate place.
+	//
+	class ClientPlaySharpShell : PlaySharpShell {
+		NetworkStream ns, interrupt_stream;
+		
+	public ClientPlaySharpShell (Evaluator evaluator, int pid)
+			: base (evaluator)
+		{
+			// Create a server socket we listen on whose address is passed to the agent
+			TcpListener listener = new TcpListener (new IPEndPoint (IPAddress.Loopback, 0));
+			listener.Start ();
+			TcpListener interrupt_listener = new TcpListener (new IPEndPoint (IPAddress.Loopback, 0));
+			interrupt_listener.Start ();
+	
+			string agent_assembly = typeof (ClientPlaySharpShell).Assembly.Location;
+			string agent_arg = String.Format ("--agent:{0}:{1}" ,
+							  ((IPEndPoint)listener.Server.LocalEndPoint).Port,
+							  ((IPEndPoint)interrupt_listener.Server.LocalEndPoint).Port);
+	
+			var vm = new Attach.VirtualMachine (pid);
+			vm.Attach (agent_assembly, agent_arg);
+	
+			/* Wait for the client to connect */
+			TcpClient client = listener.AcceptTcpClient ();
+			ns = client.GetStream ();
+			TcpClient interrupt_client = interrupt_listener.AcceptTcpClient ();
+			interrupt_stream = interrupt_client.GetStream ();
+	
+			Console.WriteLine ("Connected.");
+		}
+	
+		//
+		// A remote version of Evaluate
+		//
+		protected override string Evaluate (string input)
+		{
+			ns.WriteString (input);
+			while (true) {
+				AgentStatus s = (AgentStatus) ns.ReadByte ();
+	
+				switch (s){
+				case AgentStatus.PARTIAL_INPUT:
+					return input;
+	
+				case AgentStatus.ERROR:
+					string err = ns.GetString ();
+					Console.Error.WriteLine (err);
+					break;
+	
+				case AgentStatus.RESULT_NOT_SET:
+					return null;
+	
+				case AgentStatus.RESULT_SET:
+					string res = ns.GetString ();
+					Console.WriteLine (res);
+					return null;
+				}
+			}
+		}
+		
+		public override int Run (string [] startup_files)
+		{
+			// The difference is that we do not call Evaluator.Init, that is done on the target
+			this.startup_files = startup_files;
+			return ReadEvalPrintLoop ();
+		}
+	
+		protected override void ConsoleInterrupt (object sender, ConsoleCancelEventArgs a)
+		{
+			// Do not about our program
+			a.Cancel = true;
+	
+			interrupt_stream.WriteByte (0);
+			int c = interrupt_stream.ReadByte ();
+			if (c != -1)
+				Console.WriteLine ("Execution interrupted");
+		}
+			
+	}
+
+	//
+	// Stream helper extension methods
+	//
+	public static class StreamHelper {
+		static DataConverter converter = DataConverter.LittleEndian;
+		
+		public static int GetInt (this Stream stream)
+		{
+			byte [] b = new byte [4];
+			if (stream.Read (b, 0, 4) != 4)
+				throw new IOException ("End reached");
+			return converter.GetInt32 (b, 0);
+		}
+		
+		public static string GetString (this Stream stream)
+		{
+			int len = stream.GetInt ();
+			byte [] b = new byte [len];
+			if (stream.Read (b, 0, len) != len)
+				throw new IOException ("End reached");
+			return Encoding.UTF8.GetString (b);
+		}
+	
+		public static void WriteInt (this Stream stream, int n)
+		{
+			byte [] bytes = converter.GetBytes (n);
+			stream.Write (bytes, 0, bytes.Length);
+		}
+	
+		public static void WriteString (this Stream stream, string s)
+		{
+			stream.WriteInt (s.Length);
+			byte [] bytes = Encoding.UTF8.GetBytes (s);
+			stream.Write (bytes, 0, bytes.Length);
+		}
+	}
+	
+	public enum AgentStatus : byte {
+		// Received partial input, complete
+		PARTIAL_INPUT  = 1,
+	
+		// The result was set, expect the string with the result
+		RESULT_SET     = 2,
+	
+		// No result was set, complete
+		RESULT_NOT_SET = 3,
+	
+		// Errors and warnings string follows
+		ERROR          = 4, 
+	}
+	
+	//
+	// This is the agent loaded into the target process when using --attach.
+	//
+	class CSharpAgent
+	{
+		NetworkStream interrupt_stream;
+		readonly Evaluator evaluator;
+		TextWriter stderr;
+		
+		public CSharpAgent (Evaluator evaluator, String arg, TextWriter stderr)
+		{
+			this.evaluator = evaluator;
+			this.stderr = stderr;
+			new Thread (new ParameterizedThreadStart (Run)).Start (arg);
+		}
+
+		public void InterruptListener ()
+		{
+			while (true){
+				int b = interrupt_stream.ReadByte();
+				if (b == -1)
+					return;
+				evaluator.Interrupt ();
+				interrupt_stream.WriteByte (0);
+			}
+		}
+		
+		public void Run (object o)
+		{
+			string arg = (string)o;
+			string ports = arg.Substring (8);
+			int sp = ports.IndexOf (':');
+			int port = Int32.Parse (ports.Substring (0, sp));
+			int interrupt_port = Int32.Parse (ports.Substring (sp+1));
+	
+			Console.WriteLine ("csharp-agent: started, connecting to localhost:" + port);
+	
+			TcpClient client = new TcpClient ("127.0.0.1", port);
+			TcpClient interrupt_client = new TcpClient ("127.0.0.1", interrupt_port);
+			Console.WriteLine ("csharp-agent: connected.");
+	
+			NetworkStream s = client.GetStream ();
+			interrupt_stream = interrupt_client.GetStream ();
+			new Thread (InterruptListener).Start ();
+
+			try {
+				// Add all assemblies loaded later
+				AppDomain.CurrentDomain.AssemblyLoad += AssemblyLoaded;
+	
+				// Add all currently loaded assemblies
+				foreach (Assembly a in AppDomain.CurrentDomain.GetAssemblies ()) {
+					// Some assemblies seem to be already loaded, and loading them again causes 'defined multiple times' errors
+					if (a.GetName ().Name != "mscorlib" && a.GetName ().Name != "System.Core" && a.GetName ().Name != "System")
+						evaluator.ReferenceAssembly (a);
+				}
+	
+				RunRepl (s);
+			} finally {
+				AppDomain.CurrentDomain.AssemblyLoad -= AssemblyLoaded;
+				client.Close ();
+				interrupt_client.Close ();
+				Console.WriteLine ("csharp-agent: disconnected.");			
+			}
+		}
+	
+		void AssemblyLoaded (object sender, AssemblyLoadEventArgs e)
+		{
+			evaluator.ReferenceAssembly (e.LoadedAssembly);
+		}
+	
+		public void RunRepl (NetworkStream s)
+		{
+			string input = null;
+
+			while (!InteractiveBase.QuitRequested) {
+				try {
+					string error_string;
+					StringWriter error_output = (StringWriter)stderr;
+
+					string line = s.GetString ();
+	
+					bool result_set;
+					object result;
+	
+					if (input == null)
+						input = line;
+					else
+						input = input + "\n" + line;
+	
+					try {
+						input = evaluator.Evaluate (input, out result, out result_set);
+					} catch (Exception e) {
+						s.WriteByte ((byte) AgentStatus.ERROR);
+						s.WriteString (e.ToString ());
+						s.WriteByte ((byte) AgentStatus.RESULT_NOT_SET);
+						continue;
+					}
+					
+					if (input != null){
+						s.WriteByte ((byte) AgentStatus.PARTIAL_INPUT);
+						continue;
+					}
+	
+					// Send warnings and errors back
+					error_string = error_output.ToString ();
+					if (error_string.Length != 0){
+						s.WriteByte ((byte) AgentStatus.ERROR);
+						s.WriteString (error_output.ToString ());
+						error_output.GetStringBuilder ().Clear ();
+					}
+	
+					if (result_set){
+						s.WriteByte ((byte) AgentStatus.RESULT_SET);
+						StringWriter sr = new StringWriter ();
+						PlaySharpShell.PrettyPrint (sr, result);
+						s.WriteString (sr.ToString ());
+					} else {
+						s.WriteByte ((byte) AgentStatus.RESULT_NOT_SET);
+					}
+				} catch (IOException) {
+					break;
+				} catch (Exception e){
+					Console.WriteLine (e);
+				}
+			}
+		}
+	}
+
+	public class UnixUtils {
+		[System.Runtime.InteropServices.DllImport ("libc", EntryPoint="isatty")]
+		extern static int _isatty (int fd);
+			
+		public static bool isatty (int fd)
+		{
+			try {
+				return _isatty (fd) == 1;
+			} catch {
+				return false;
+			}
+		}
+	}
+#endif
+}
+	
+namespace Mono.Management
+{
+	interface IVirtualMachine {
+		void LoadAgent (string filename, string args);
+	}
+}


### PR DESCRIPTION
- Added playshell : This is a PlayScript REPL (aka: like csharp REPL)
  - For use with Tamarin Redux test; they use Asset scripts with a test package
  - Very alpha at this point
  - Need to add PlayScript style 'import'
- Added PsOnlyMode to compiler setting
  - Whether to enable PlayScript compiler only mode. Defaults to false.
- mcs.master.mdw : XS/MD Workspace that will hold Solutions for all mcs
  - Added tools/csharp and tools/playshell
- CSProj files updated via Make2CSProjUpdater to allow use in XS/MD:
  - Mono.PlayScript.csproj (and .sln)
  - Mono.CSharp.csproj (and .sln)
  - tools/charp.csproj (and .sln)
  - tools/playshell.csproj (and .sln)
