### PR TITLE
Migrate changes from ICSharpCode.NRefactory.PlayScript/Parser/mcs

### DIFF
--- a/mcs/class/pscorlib/Array.cs
+++ b/mcs/class/pscorlib/Array.cs
@@ -315,16 +315,16 @@ namespace _root
 			get {
 				if (mImmutableArray != null)
 					return mImmutableArray.getObjectAt ((uint)i);
-				#if PERFORMANCE_MODE && DEBUG
+				#if PERFORMANCE_MODEz && DEBUGz
 				if ((i >= mCount) || (i < 0))
 				{
 					throw new IndexOutOfRangeException();
 				}
-				#elif PERFORMANCE_MODE
+				#elif PERFORMANCE_MODEz
 				#else
 				if ((i >= mCount) || (i < 0))
 				{
-					Console.WriteLine ("undef : " + Undefined._undefined);
+//					Console.WriteLine ("undef : " + Undefined._undefined);
 					return Undefined._undefined;
 				}
 				#endif
@@ -335,13 +335,13 @@ namespace _root
 			set {
 				if (mImmutableArray != null)
 					ConvertToMutable ();
-				#if PERFORMANCE_MODE && DEBUG
+				#if PERFORMANCE_MODEz && DEBUGz
 				if (i >= mCount) {
 //					return Undefined._undefined;
 					// TODO : Fix this (?)
 					throw new IndexOutOfRangeException();
 				}
-				#elif PERFORMANCE_MODE
+				#elif PERFORMANCE_MODEz
 				#else
 				if (i >= mCount) {
 					expand((uint)(i+1));

--- a/mcs/class/pscorlib/flash/text/TextField.play
+++ b/mcs/class/pscorlib/flash/text/TextField.play
@@ -178,7 +178,8 @@ package flash.text {
 		}
  	 	
 		public function appendText(newText:String):void {
-			throw new NotImplementedException();
+			this.text = this.text + newText;
+			//throw new NotImplementedException();
 		}
 
 		public function getCharBoundaries(charIndex:int):Rectangle {

--- a/mcs/mcs/anonymous.cs
+++ b/mcs/mcs/anonymous.cs
@@ -995,6 +995,11 @@ namespace Mono.CSharp {
 			}
 		}
 
+		public bool IsAsync {
+			get;
+			internal set;
+		}
+
 		public ReportPrinter TypeInferenceReportPrinter {
 			get; set;
 		}

--- a/mcs/mcs/assign.cs
+++ b/mcs/mcs/assign.cs
@@ -786,6 +786,12 @@ namespace Mono.CSharp {
 		Expression right;
 		Expression left;
 
+		public Binary.Operator Op {
+			get {
+				return op;
+			}
+		}
+
 		public CompoundAssign (Binary.Operator op, Expression target, Expression source)
 			: base (target, source, target.Location)
 		{

--- a/mcs/mcs/async.cs
+++ b/mcs/mcs/async.cs
@@ -30,6 +30,12 @@ namespace Mono.CSharp
 		Expression expr;
 		AwaitStatement stmt;
 
+		public Expression Expression {
+			get {
+				return expr;
+			}
+		}
+
 		public Await (Expression expr, Location loc)
 		{
 			this.expr = expr;

--- a/mcs/mcs/attribute.cs
+++ b/mcs/mcs/attribute.cs
@@ -156,6 +156,12 @@ namespace Mono.CSharp {
 			}
 		}
 
+		public ATypeNameExpression TypeNameExpression {
+			get {
+				return expression;
+			}
+		}
+
 		void AddModuleCharSet (ResolveContext rc)
 		{
 			const string dll_import_char_set = "CharSet";
@@ -1201,16 +1207,26 @@ namespace Mono.CSharp {
 	public partial class Attributes
 	{
 		public readonly List<Attribute> Attrs;
+		#if FULL_AST
+		public readonly List<List<Attribute>> Sections = new List<List<Attribute>> ();
+		#endif
 
 		public Attributes (Attribute a)
 		{
 			Attrs = new List<Attribute> ();
 			Attrs.Add (a);
+			#if FULL_AST
+			Sections.Add (Attrs);
+			#endif
+
 		}
 
 		public Attributes (List<Attribute> attrs)
 		{
 			Attrs = attrs ?? new List<Attribute> ();
+			#if FULL_AST
+			Sections.Add (attrs);
+			#endif
 		}
 
 		public void AddAttribute (Attribute attr)
@@ -1220,7 +1236,11 @@ namespace Mono.CSharp {
 
 		public void AddAttributes (List<Attribute> attrs)
 		{
+			#if FULL_AST
+			Sections.Add (attrs);
+			#else
 			Attrs.AddRange (attrs);
+			#endif
 		}
 
 		public void AttachTo (Attributable attributable, IMemberContext context)

--- a/mcs/mcs/class.cs
+++ b/mcs/mcs/class.cs
@@ -707,6 +707,12 @@ namespace Mono.CSharp
 			}
 		}
 
+		public List<FullNamedExpression> TypeBaseExpressions {
+			get {
+				return type_bases;
+			}
+		}
+
 		public bool HasInstanceConstructor {
 			get {
 				return (caching_flags & Flags.HasInstanceConstructor) != 0;

--- a/mcs/mcs/cs-tokenizer.cs
+++ b/mcs/mcs/cs-tokenizer.cs
@@ -305,6 +305,15 @@ namespace Mono.CSharp
 
 		static readonly char[] simple_whitespaces = new char[] { ' ', '\t' };
 
+		public int Column {
+			get {
+				return col;
+			}
+			set {
+				col = value;
+			}
+		}
+			
 		public bool PropertyParsing {
 			get { return handle_get_set; }
 			set { handle_get_set = value; }
@@ -380,6 +389,9 @@ namespace Mono.CSharp
 		public int Line {
 			get {
 				return ref_line;
+			}
+			set {
+				ref_line = value;
 			}
 		}
 

--- a/mcs/mcs/delegate.cs
+++ b/mcs/mcs/delegate.cs
@@ -30,7 +30,7 @@ namespace Mono.CSharp {
 	//
 	public class Delegate : TypeDefinition, IParametersMember
 	{
- 		FullNamedExpression ReturnType;
+ 		public FullNamedExpression ReturnType;
 		readonly ParametersCompiled parameters;
 
 		Constructor Constructor;

--- a/mcs/mcs/driver.cs
+++ b/mcs/mcs/driver.cs
@@ -200,7 +200,21 @@ namespace Mono.CSharp
 				parser.parse ();
 			}
 		}
-		
+
+		public static PlayScriptParser PsParse (SeekableStreamReader reader, SourceFile sourceFile, ModuleContainer module, ParserSession session, Report report, int lineModifier = 0, int colModifier = 0)
+		{
+			var file = new CompilationSourceFile (module, sourceFile);
+			module.AddTypeContainer (file);
+
+			var parser = new PlayScriptParser (reader, file, report, session);
+			parser.parsing_playscript = sourceFile.PsExtended;
+			parser.Lexer.Line += lineModifier;
+			parser.Lexer.Column += colModifier;
+			parser.Lexer.sbag = new SpecialsBag ();
+			parser.parse ();
+			return parser;
+		}
+
 		public static int Main (string[] args)
 		{
 			Location.InEmacs = Environment.GetEnvironmentVariable ("EMACS") == "t";
@@ -441,6 +455,14 @@ namespace Mono.CSharp
 
 			return Report.Errors == 0;
 		}
+	}
+
+	public class CompilerCompilationUnit {
+		public ModuleContainer ModuleCompiled { get; set; }
+		public LocationsBag LocationsBag { get; set; }
+		public SpecialsBag SpecialsBag { get; set; }
+		public IDictionary<string, bool> Conditionals { get; set; }
+		public object LastYYValue { get; set; }
 	}
 
 	//

--- a/mcs/mcs/ecore.cs
+++ b/mcs/mcs/ecore.cs
@@ -7812,4 +7812,48 @@ namespace Mono.CSharp {
 				ec.Module.Compiler.Report.Error (825, loc, "The contextual keyword `var' may only appear within a local variable declaration");
 		}
 	}
-}	
+
+	public class InvalidStatementExpression : Statement
+	{
+		public Expression Expression {
+			get;
+			private set;
+		}
+
+		public InvalidStatementExpression (Expression expr)
+		{
+			this.Expression = expr;
+		}
+
+		public override void Emit (EmitContext ec)
+		{
+			// nothing
+		}
+
+		protected override void DoEmit (EmitContext ec)
+		{
+			// nothing
+		}
+
+		protected override void CloneTo (CloneContext clonectx, Statement target)
+		{
+			// nothing
+		}
+
+		public override Expression CreateExpressionTree (ResolveContext ec)
+		{
+			return null;
+		}
+
+		public override object Accept (StructuralVisitor visitor)
+		{
+			return visitor.Visit (this);
+		}
+
+		protected override bool DoFlowAnalysis(FlowAnalysisContext fc)
+		{
+			return false;
+		}
+	}
+
+}

--- a/mcs/mcs/expression.cs
+++ b/mcs/mcs/expression.cs
@@ -8205,6 +8205,12 @@ namespace Mono.CSharp
 			}
 		}
 
+		public Expression TypeRequested {
+			get {
+				return RequestedType;
+			}
+		}
+
 		//
 		// Returns true for resolved `new S()' when S does not declare parameterless constructor
 		//
@@ -8839,6 +8845,10 @@ namespace Mono.CSharp
 			get {
 				return this.initializers;
 			}
+		}
+
+		public List<Expression> Arguments {
+			get { return this.arguments; }
 		}
 
 		bool CheckIndices (ResolveContext ec, ArrayInitializer probe, int idx, bool specified_dims, int child_bounds)
@@ -9974,6 +9984,10 @@ namespace Mono.CSharp
 	{
 		FullNamedExpression texpr;
 
+		public FullNamedExpression FullNamedExpression {
+			get { return texpr;}
+		}
+
 		public RefValueExpr (Expression expr, FullNamedExpression texpr, Location loc)
 			: base (expr)
 		{
@@ -10504,7 +10518,7 @@ namespace Mono.CSharp
 	/// </summary>
 	public class QualifiedAliasMember : MemberAccess
 	{
-		readonly string alias;
+		public readonly string alias;
 		public static readonly string GlobalAlias = "global";
 
 		public QualifiedAliasMember (string alias, string identifier, Location l)
@@ -12607,7 +12621,17 @@ namespace Mono.CSharp
 	public class ComposedCast : TypeExpr {
 		FullNamedExpression left;
 		ComposedTypeSpecifier spec;
-		
+
+		public FullNamedExpression Left {
+			get { return this.left; }
+		}
+
+		public ComposedTypeSpecifier Spec {
+			get {
+				return this.spec;
+			}
+		}
+
 		public ComposedCast (FullNamedExpression left, ComposedTypeSpecifier spec)
 		{
 			if (spec == null)
@@ -13038,6 +13062,8 @@ namespace Mono.CSharp
 	//
 	class CollectionElementInitializer : Invocation
 	{
+		public readonly bool IsSingle;
+
 		public class ElementInitializerArgument : Argument
 		{
 			public ElementInitializerArgument (Expression e)
@@ -13065,6 +13091,7 @@ namespace Mono.CSharp
 		public CollectionElementInitializer (Expression argument)
 			: base (null, new Arguments (1))
 		{
+			IsSingle = true;
 			base.arguments.Add (new ElementInitializerArgument (argument));
 			this.loc = argument.Location;
 		}
@@ -13072,6 +13099,7 @@ namespace Mono.CSharp
 		public CollectionElementInitializer (List<Expression> arguments, Location loc)
 			: base (null, new Arguments (arguments.Count))
 		{
+			IsSingle = false;
 			foreach (Expression e in arguments)
 				base.arguments.Add (new ElementInitializerArgument (e));
 

--- a/mcs/mcs/generic.cs
+++ b/mcs/mcs/generic.cs
@@ -122,7 +122,13 @@ namespace Mono.CSharp {
 		readonly Location loc;
 		bool resolved;
 		bool resolving;
-		
+
+		public IEnumerable<FullNamedExpression> ConstraintExpressions {
+			get {
+				return constraints;
+			}
+		}
+
 		public Constraints (SimpleMemberName tparam, List<FullNamedExpression> constraints, Location loc)
 		{
 			this.tparam = tparam;
@@ -2136,6 +2142,10 @@ namespace Mono.CSharp {
 	{
 		List<FullNamedExpression> args;
 		TypeSpec[] atypes;
+
+		public List<FullNamedExpression> Args {
+			get { return this.args; }
+		}
 
 		public TypeArguments (params FullNamedExpression[] types)
 		{

--- a/mcs/mcs/linq.cs
+++ b/mcs/mcs/linq.cs
@@ -277,6 +277,12 @@ namespace Mono.CSharp.Linq
 
 		protected RangeVariable identifier;
 
+		public RangeVariable  IntoVariable {
+			get {
+				return identifier;
+			}
+		}
+
 		protected ARangeVariableQueryClause (QueryBlock block, RangeVariable identifier, Expression expr, Location loc)
 			: base (block, expr, loc)
 		{
@@ -449,6 +455,10 @@ namespace Mono.CSharp.Linq
 		Expression element_selector;
 		QueryBlock element_block;
 
+		public Expression ElementSelector {
+			get { return this.element_selector; }
+		}
+
 		public GroupBy (QueryBlock block, Expression elementSelector, QueryBlock elementBlock, Expression keySelector, Location loc)
 			: base (block, keySelector, loc)
 		{
@@ -506,6 +516,10 @@ namespace Mono.CSharp.Linq
 	{
 		QueryBlock inner_selector, outer_selector;
 
+		public RangeVariable JoinVariable {
+			get { return this.GetIntoVariable (); }
+		}
+			
 		public Join (QueryBlock block, RangeVariable lt, Expression inner, QueryBlock outerSelector, QueryBlock innerSelector, Location loc)
 			: base (block, lt, inner, loc)
 		{

--- a/mcs/mcs/ps-tokenizer.cs
+++ b/mcs/mcs/ps-tokenizer.cs
@@ -189,6 +189,7 @@ namespace Mono.PlayScript
 
 		readonly SeekableStreamReader reader;
 		readonly CompilationSourceFile source_file;
+		public CompilationSourceFile SourceFile { get { return source_file; } }
 		readonly CompilerContext context;
 		readonly Report Report;
 
@@ -326,6 +327,7 @@ namespace Mono.PlayScript
 		static readonly char[] line_default = "default".ToCharArray ();
 
 		static readonly char[] simple_whitespaces = new char[] { ' ', '\t' };
+		internal SpecialsBag sbag;
 
 		public bool ParsingPlayScript {
 			get { return parsing_playscript; }
@@ -472,6 +474,18 @@ namespace Mono.PlayScript
 		public int Line {
 			get {
 				return ref_line;
+			}
+			set {
+				ref_line = value;
+			}
+		}
+
+		public int Column {
+			get {
+				return col;
+			}
+			set {
+				col = value;
 			}
 		}
 

--- a/mcs/mcs/statement.cs
+++ b/mcs/mcs/statement.cs
@@ -7416,6 +7416,14 @@ namespace Mono.CSharp {
 		List<Label> redirected_jumps;
 		Label? start_fin_label;
 
+		public Statement Stmt {
+			get { return this.stmt; }
+		}
+
+		public ExplicitBlock Fini {
+			get { return this.fini; }
+		}
+
 		public TryFinally (Statement stmt, ExplicitBlock fini, Location loc)
 			 : base (stmt, loc)
 		{

--- a/mcs/mcs/support.cs
+++ b/mcs/mcs/support.cs
@@ -244,7 +244,14 @@ namespace Mono.CSharp {
 
 			return pos < char_count;
 		}
-
+		
+		public char GetChar (int position)
+		{
+			if (buffer_start <= position && position < buffer.Length)
+				return buffer[position];
+			return '\0';
+		}
+		
 		public char[] ReadChars (int fromPosition, int toPosition)
 		{
 			char[] chars = new char[toPosition - fromPosition];

--- a/mcs/mcs/visit.cs
+++ b/mcs/mcs/visit.cs
@@ -56,6 +56,10 @@ namespace Mono.CSharp
 			}
 		}
 
+		public virtual void Visit (UsingClause usingClause)
+		{
+		}
+
 		public virtual void Visit (ModuleContainer module)
 		{
 			if (!AutoVisit)


### PR DESCRIPTION
Migrate changes from ICSharpCode.NRefactory.PlayScript/Parser/mcs to reduce the code differences and allow cleaner merges. 

TODO: Refactor the namespace to allow same `mcs`/`psc` code to be shared among projects
